### PR TITLE
Sync Quark Right Click Sign Edit

### DIFF
--- a/src/main/java/rlmixins/RLMixins.java
+++ b/src/main/java/rlmixins/RLMixins.java
@@ -13,6 +13,8 @@ import rlmixins.handlers.bountifulbaubles.CobaltShieldBaubleHandler;
 import rlmixins.handlers.bountifulbaubles.FireResistanceBaubleHandler;
 import rlmixins.handlers.chunkanimator.ChunkAnimatorCooldownHandler;
 import rlmixins.handlers.iceandfire.WeaponModifierHandler;
+import rlmixins.handlers.quark.PacketHandler;
+import rlmixins.handlers.quark.RightClickSignEditHandler;
 import rlmixins.handlers.inspirations.MilkCooldownHandler;
 import rlmixins.handlers.reskillable.UndershirtHandler;
 import rlmixins.handlers.rlmixins.LesserFireResistanceHandler;
@@ -41,11 +43,17 @@ public class RLMixins
         ModRegistry.init();
         RLMixins.PROXY.preInit();
 
+        if (ForgeConfigHandler.mixinConfig.fixRightClickSignEdit) {
+            PacketHandler.init();
+            MinecraftForge.EVENT_BUS.register(new RightClickSignEditHandler());
+        }
+
         if(ForgeConfigHandler.mixinConfig.brokenHeartRework) MinecraftForge.EVENT_BUS.register(BrokenHeartBaubleHandler.class);
         if(ForgeConfigHandler.mixinConfig.obsidianResistanceRework) MinecraftForge.EVENT_BUS.register(FireResistanceBaubleHandler.class);
         if(ForgeConfigHandler.mixinConfig.chunkAnimatorXRay) MinecraftForge.EVENT_BUS.register(ChunkAnimatorCooldownHandler.class);
         if(ForgeConfigHandler.mixinConfig.cancelIceAndFireBonusHandling) MinecraftForge.EVENT_BUS.register(WeaponModifierHandler.class);
         if(ForgeConfigHandler.mixinConfig.undershirtRework) MinecraftForge.EVENT_BUS.register(UndershirtHandler.class);
+
         if(ForgeConfigHandler.mixinConfig.overhaulEnchants) {
             MinecraftForge.EVENT_BUS.register(ArcSlashHandler.class);
             MinecraftForge.EVENT_BUS.register(AtomicDeconstructorHandler.class);

--- a/src/main/java/rlmixins/handlers/ForgeConfigHandler.java
+++ b/src/main/java/rlmixins/handlers/ForgeConfigHandler.java
@@ -365,6 +365,10 @@ public class ForgeConfigHandler {
 		@Config.RequiresMcRestart
 		public boolean teleportCollisionPatch = false;
 
+		@Config.Comment("If true, fix quark right click sign edit config option")
+		@Config.Name("Fix Right Click Sign Edit Option (Quark)")
+		public boolean fixRightClickSignEdit = true;
+
 		@Config.Comment("Makes feathers not passively drop from chickens if they're stoned")
 		@Config.Name("Stoned Chicken Feather Fix (Quark/IceAndFire)")
 		@Config.RequiresMcRestart

--- a/src/main/java/rlmixins/handlers/quark/PacketHandler.java
+++ b/src/main/java/rlmixins/handlers/quark/PacketHandler.java
@@ -1,0 +1,17 @@
+package rlmixins.handlers.quark;
+
+import net.minecraftforge.fml.common.network.NetworkRegistry;
+import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
+import net.minecraftforge.fml.relauncher.Side;
+import rlmixins.RLMixins;
+
+public class PacketHandler {
+    public static final SimpleNetworkWrapper instance = NetworkRegistry.INSTANCE.newSimpleChannel(RLMixins.MODID);
+
+    public PacketHandler() {
+    }
+
+    public static void init() {
+        instance.registerMessage(RightClickSignEditHandler.MessageSyncConfig.Handler.class, RightClickSignEditHandler.MessageSyncConfig.class, 0, Side.CLIENT);
+    }
+}

--- a/src/main/java/rlmixins/mixin/RLMixinsMixinLoader.java
+++ b/src/main/java/rlmixins/mixin/RLMixinsMixinLoader.java
@@ -45,6 +45,7 @@ public class RLMixinsMixinLoader {
         map.put("HungryFarmer Blacklist (Reskillable)", "mixins.rlmixins.hungryfarmer.json");
         map.put("Undershirt Rework (Reskillable/FirstAid)", "mixins.rlmixins.undershirt.json");
         map.put("Stoneling Dupe Patch (Quark)", "mixins.rlmixins.stoneling.json");
+        map.put("Fix Right Click Sign Edit Option (Quark)", "mixins.rlmixins.quarksignedit.json");
         map.put("Delayed Launch (PotionCore)", "mixins.rlmixins.delayedlaunch.json");
         map.put("Half Reach (PotionCore)", "mixins.rlmixins.halfreach.json");
         map.put("Lycanite Render Box (LycanitesMobs)", "mixins.rlmixins.lycaniterender.json");
@@ -89,6 +90,7 @@ public class RLMixinsMixinLoader {
 
         return Collections.unmodifiableMap(map);
     }
+
     @Shadow(remap = false)
     private List<ModContainer> mods;
     @Shadow(remap = false)
@@ -110,8 +112,8 @@ public class RLMixinsMixinLoader {
         }
 
         // Add and reload mixin configs
-        for(Map.Entry<String, String> entry : configMap.entrySet()) {
-            if(ForgeConfigHandler.getBoolean(entry.getKey())) {
+        for (Map.Entry<String, String> entry : configMap.entrySet()) {
+            if (ForgeConfigHandler.getBoolean(entry.getKey())) {
                 RLMixins.LOGGER.log(Level.INFO, "RLMixins Late Loading: " + entry.getKey());
                 Mixins.addConfiguration(entry.getValue());
             }

--- a/src/main/java/rlmixins/mixin/quark/RightClickSignEditMixin.java
+++ b/src/main/java/rlmixins/mixin/quark/RightClickSignEditMixin.java
@@ -28,8 +28,6 @@ public abstract class RightClickSignEditMixin implements IGuiHandler {
     private void m_quarkRightClickSignEdit_getClientGuiElement(EntityPlayer instance, Object mod, int modGuiId, World world, int x, int y, int z) {
         if (RightClickSignEditHandler.isEnabled) {
             instance.openGui(Quark.instance, 0, world, x, y, z);
-        } else {
-            MinecraftForge.EVENT_BUS.unregister(this);
         }
     }
 }

--- a/src/main/java/rlmixins/mixin/quark/RightClickSignEditMixin.java
+++ b/src/main/java/rlmixins/mixin/quark/RightClickSignEditMixin.java
@@ -1,0 +1,35 @@
+package rlmixins.mixin.quark;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.network.IGuiHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import rlmixins.handlers.quark.RightClickSignEditHandler;
+import vazkii.quark.base.Quark;
+import vazkii.quark.tweaks.feature.RightClickSignEdit;
+
+@Mixin(RightClickSignEdit.class)
+public abstract class RightClickSignEditMixin implements IGuiHandler {
+    /**
+     * Fix Quark configuration for Right Click Sign Edit.
+     * This is done by syncing the configuration with the client using packets.
+     */
+    @Redirect(
+            method = "onInteract",
+            at = @At(value = "INVOKE",
+                    target = "Lnet/minecraft/entity/player/EntityPlayer;openGui(Ljava/lang/Object;ILnet/minecraft/world/World;III)V",
+                    remap = true),
+            remap = false
+    )
+    private void m_quarkRightClickSignEdit_getClientGuiElement(EntityPlayer instance, Object mod, int modGuiId, World world, int x, int y, int z) {
+        if (RightClickSignEditHandler.isEnabled) {
+            instance.openGui(Quark.instance, 0, world, x, y, z);
+        } else {
+            MinecraftForge.EVENT_BUS.unregister(this);
+        }
+    }
+}

--- a/src/main/resources/mixins.rlmixins.quarksignedit.json
+++ b/src/main/resources/mixins.rlmixins.quarksignedit.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "package": "rlmixins.mixin",
+  "refmap": "mixins.rlmixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "quark.RightClickSignEditMixin"
+  ],
+  "injectors": {
+    "maxShiftBy": 0
+  }
+}


### PR DESCRIPTION
The objective of this PR is to synchronize the configuration value of the "right click sign edit" feature in the Quark mod to the client, thereby resolving various issues encountered on servers that aim to disable this Quark feature.