### PR TITLE
Introduce mixin for parasites adapting incorrectly to indirect damage

### DIFF
--- a/src/main/java/rlmixins/RLMixinsPlugin.java
+++ b/src/main/java/rlmixins/RLMixinsPlugin.java
@@ -134,6 +134,7 @@ public class RLMixinsPlugin implements IFMLLoadingPlugin {
 		map.put("Quark Chat Link NBT Crash (Quark)", "mixins.rlmixins.chatlinkcrash.json");
 		map.put("Potion Amplifier Visibility (DSHuds)", "mixins.rlmixins.dshudpotion.json");
 		map.put("Parasite Cleaver Effect Config (SRParasites)", "mixins.rlmixins.cleaverpotion.json");
+		map.put("Parasite Indirect Damage Adaption Fix (SRParasites)", "mixins.rlmixins.indirectadaption.json");
 		map.put("Better Foliage Chunk XRay (BetterFoliage/ChunkAnimator)", "mixins.rlmixins.betterfoliagechunkanimator.json");
 		map.put("CarryOn Ungenerated Chest Patch (CarryOn)", "mixins.rlmixins.carryonunlooted.json");
 		map.put("CarryOn Pig Saddle Patch (CarryOn)", "mixins.rlmixins.carryonpig.json");

--- a/src/main/java/rlmixins/handlers/ForgeConfigHandler.java
+++ b/src/main/java/rlmixins/handlers/ForgeConfigHandler.java
@@ -466,6 +466,11 @@ public class ForgeConfigHandler {
 		@Config.RequiresMcRestart
 		public boolean parasiteCleaverCustomEffect = false;
 
+		@Config.Comment("Updates the adaption for indirect attacks to ignore the true damage source")
+		@Config.Name("Parasite Indirect Damage Adaption Fix (SRParasites)")
+		@Config.RequiresMcRestart
+		public boolean parasiteIndirectDamageAdaptionFix = false;
+
 		@Config.Comment("Stops Better Foliage's enable toggle from Chunk Animator XRaying")
 		@Config.Name("Better Foliage Chunk XRay (BetterFoliage/ChunkAnimator)")
 		@Config.RequiresMcRestart

--- a/src/main/java/rlmixins/mixin/srparasites/EntityPMalleableMixin.java
+++ b/src/main/java/rlmixins/mixin/srparasites/EntityPMalleableMixin.java
@@ -1,0 +1,37 @@
+package rlmixins.mixin.srparasites;
+
+import com.dhanantry.scapeandrunparasites.entity.ai.misc.EntityPMalleable;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.DamageSource;
+import net.minecraft.util.EntityDamageSourceIndirect;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(EntityPMalleable.class)
+public abstract class EntityPMalleableMixin {
+
+    @Redirect(
+            method = "func_70097_a",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/util/DamageSource;func_76364_f()Lnet/minecraft/entity/Entity;"),
+            remap = false
+    )
+    private Entity rlmixins_srparasitesEntityPMalleable_func_76364_f(DamageSource source) {
+        if (source instanceof EntityDamageSourceIndirect) {
+            return null;
+        }
+        return source.getImmediateSource();
+    }
+
+    @Redirect(
+            method = "func_70097_a",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/util/DamageSource;func_76346_g()Lnet/minecraft/entity/Entity;"),
+            remap = false
+    )
+    private Entity rlmixins_srparasitesEntityPMalleable_func_76346_g(DamageSource source) {
+        if (source instanceof EntityDamageSourceIndirect) {
+            return null;
+        }
+        return source.getTrueSource();
+    }
+}

--- a/src/main/resources/mixins.rlmixins.indirectadaption.json
+++ b/src/main/resources/mixins.rlmixins.indirectadaption.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "package": "rlmixins.mixin",
+  "refmap": "mixins.rlmixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "srparasites.EntityPMalleableMixin"
+  ],
+  "injectors": {
+    "maxShiftBy": 10
+  }
+}


### PR DESCRIPTION
Without these changes, parasites will adapt to the weapon or item in the mainhand, in the case of adaption, whenever the source of the damage (immediate or true) is a player. Meaning, if a parasite is hit from an arrow, throwing weapon, or from chain lightning, as some examples, the parasite will adapt to the weapon in the mainhand. With these changes, the adaption will instead be to the damage-source ("thrown", "arrow", "lightningBolt", etc).