### PR TITLE
Fix Waystones' NameGenerator mixin

### DIFF
--- a/src/main/java/rlmixins/mixin/waystones/NameGeneratorMixin.java
+++ b/src/main/java/rlmixins/mixin/waystones/NameGeneratorMixin.java
@@ -80,12 +80,15 @@ public abstract class NameGeneratorMixin extends WorldSavedData {
             count = this.rlmixins$usedNamesMap.getInt(name);
             if(count > 0) name = name + " " + RomanNumber.toRoman(count);
         }
-        if(!ForgeConfigHandler.server.waystonesIgnoreUsedNames) this.rlmixins$usedNamesMap.put(baseName, count+1);
 
         GenerateWaystoneNameEvent event = new GenerateWaystoneNameEvent(pos, dimension, name);
-        //TODO: Allow changing name from event (Probably not im lazy)
         MinecraftForge.EVENT_BUS.post(event);
+        if(!Objects.equals(name, event.getWaystoneName())) {
+            baseName = name = event.getWaystoneName();
+            count = this.rlmixins$usedNamesMap.getInt(name);
+        }
 
+        if(!ForgeConfigHandler.server.waystonesIgnoreUsedNames) this.rlmixins$usedNamesMap.put(baseName, count+1);
         this.markDirty();
         return name;
     }

--- a/src/main/java/rlmixins/mixin/waystones/NameGeneratorMixin.java
+++ b/src/main/java/rlmixins/mixin/waystones/NameGeneratorMixin.java
@@ -52,13 +52,14 @@ public abstract class NameGeneratorMixin extends WorldSavedData {
     public String getName(BlockPos pos, int dimension, Biome biome, Random rand) {
         if(this.BIOME_NAMES == null) this.init();
 
+        String baseName = null;
         String name = null;
         List<String> customNames = Arrays.asList(WaystoneConfig.worldGen.customNames);
         Collections.shuffle(customNames);
 
         for(String tryName : customNames) {
             if(!this.rlmixins$usedNamesMap.containsKey(tryName)) {
-                name = tryName;
+                baseName = name = tryName;
                 break;
             }
         }
@@ -74,12 +75,12 @@ public abstract class NameGeneratorMixin extends WorldSavedData {
                 }
             }
             String biomeSuffix = isVillage ? null : this.BIOME_NAMES.get(((BiomeAccessor)biome).getBiomeName());
-            name = this.randomName(rand) + (biomeSuffix != null ? " " + biomeSuffix : "");
+            baseName = name = this.randomName(rand) + (biomeSuffix != null ? " " + biomeSuffix : "");
 
             count = this.rlmixins$usedNamesMap.getInt(name);
             if(count > 0) name = name + " " + RomanNumber.toRoman(count);
         }
-        if(!ForgeConfigHandler.server.waystonesIgnoreUsedNames) this.rlmixins$usedNamesMap.put(name, count+1);
+        if(!ForgeConfigHandler.server.waystonesIgnoreUsedNames) this.rlmixins$usedNamesMap.put(baseName, count+1);
 
         GenerateWaystoneNameEvent event = new GenerateWaystoneNameEvent(pos, dimension, name);
         //TODO: Allow changing name from event (Probably not im lazy)


### PR DESCRIPTION
The NameGenerator mixin calls `rlmixins$usedNamesMap.getInt(name)` to get how often a name has been used, then appends that number to the name and then calls `this.rlmixins$usedNamesMap.put(name, count+1)` to update how often the name has been used. The problem is that it uses the "base" name without any number appended when calling `getInt` but then uses the name with the number appended when calling `put`.
This results in the `getName` method always returning the base name with _one_ appended when the base name has been used one or more times.

This PR fixes this issue and also fixes the result of the `GenerateWaystoneNameEvent` being ignored.