### PR TITLE
Fixed Invert Potion Exploit

### DIFF
--- a/src/main/java/rlmixins/RLMixinsPlugin.java
+++ b/src/main/java/rlmixins/RLMixinsPlugin.java
@@ -110,6 +110,7 @@ public class RLMixinsPlugin implements IFMLLoadingPlugin {
 		map.put("Stoneling Dupe Patch (Quark)", "mixins.rlmixins.stoneling.json");
 		map.put("Delayed Launch (PotionCore)", "mixins.rlmixins.delayedlaunch.json");
 		map.put("Half Reach (PotionCore)", "mixins.rlmixins.halfreach.json");
+		map.put("Invert Buffs Only (PotionCore)", "mixins.rlmixins.invertbuffsonly.json");
 		map.put("Lycanite Render Box (LycanitesMobs)", "mixins.rlmixins.lycaniterender.json");
 		map.put("Lycanite Targetting (LycanitesMobs/IceAndFire)", "mixins.rlmixins.lycanitetargetting.json");
 		map.put("Stoned Horse Kill (CallableHorses/IceAndFire)", "mixins.rlmixins.stonedcallablehorsekill.json");

--- a/src/main/java/rlmixins/handlers/ForgeConfigHandler.java
+++ b/src/main/java/rlmixins/handlers/ForgeConfigHandler.java
@@ -195,6 +195,11 @@ public class ForgeConfigHandler {
 		@Config.RequiresMcRestart
 		public boolean halfReach = false;
 
+		@Config.Comment("Invert potion only turns Positive -> Negative")
+		@Config.Name("Invert Buffs Only (PotionCore)")
+		@Config.RequiresMcRestart
+		public boolean invertBuffsOnly = false;
+
 		@Config.Comment("Modify the render bounding boxes of some Lycanite mobs to fix under/oversized render boxes")
 		@Config.Name("Lycanite Render Box (LycanitesMobs)")
 		@Config.RequiresMcRestart

--- a/src/main/java/rlmixins/handlers/ForgeConfigHandler.java
+++ b/src/main/java/rlmixins/handlers/ForgeConfigHandler.java
@@ -1480,6 +1480,8 @@ public class ForgeConfigHandler {
 		public String[] reskillablePerfectRecoverSilkBlocks = {
 				"minecraft:glass",
 				"minecraft:glass_pane",
+				"minecraft:stained_glass",
+				"minecraft:stained_glass_pane",
 				"minecraft:ice",
 				"minecraft:magma"
 		};
@@ -1877,7 +1879,6 @@ public class ForgeConfigHandler {
 		@Config.Comment("XP orbs will only start merging if they existed for at least this many ticks.")
 		@Config.Name("XP Orb earliest merge tick")
 		public int orbMergeEarliestTick = 100;
-    }
 
 		@Config.Comment("Allows for overriding orbital period calculation result in the format String name, double value")
 		@Config.Name("Advanced Rocketry Orbital Period Overrides")

--- a/src/main/java/rlmixins/handlers/reskillable/PerfectRecoverHandler.java
+++ b/src/main/java/rlmixins/handlers/reskillable/PerfectRecoverHandler.java
@@ -20,7 +20,7 @@ public class PerfectRecoverHandler {
                 ReskillableRegistries.UNLOCKABLES.getValue(new ResourceLocation(LibMisc.MOD_ID, "perfect_recover")))) {
             if(ForgeConfigHandler.getReskillablePerfectRecoverList().contains(event.getState().getBlock())) {
                 event.getDrops().clear();
-                event.getDrops().add(new ItemStack(event.getState().getBlock(), 1));
+                event.getDrops().add(new ItemStack(event.getState().getBlock(), 1, event.getState().getBlock().getMetaFromState(event.getState())));
             }
         }
     }

--- a/src/main/java/rlmixins/mixin/potioncore/PotionInvertMixin.java
+++ b/src/main/java/rlmixins/mixin/potioncore/PotionInvertMixin.java
@@ -1,0 +1,21 @@
+package rlmixins.mixin.potioncore;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.tmtravlr.potioncore.potion.PotionInvert;
+import net.minecraft.potion.PotionEffect;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(PotionInvert.class)
+public abstract class PotionInvertMixin {
+
+    @ModifyExpressionValue(
+            method = "invertPotionEffects",
+            at = @At(value = "INVOKE", target = "Ljava/util/HashMap;containsKey(Ljava/lang/Object;)Z"),
+            remap = false
+    )
+    private static boolean rlmixins_potionCorePotionInvert_invertPotionEffects(boolean original, @Local PotionEffect effect){
+        return original && !effect.getPotion().isBadEffect();
+    }
+}

--- a/src/main/resources/mixins.rlmixins.invertbuffsonly.json
+++ b/src/main/resources/mixins.rlmixins.invertbuffsonly.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "package": "rlmixins.mixin",
+  "refmap": "mixins.rlmixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "potioncore.PotionInvertMixin"
+  ],
+  "injectors": {
+    "maxShiftBy": 10
+  }
+}


### PR DESCRIPTION
Fixed Invert Potion Exploit by making it only turn positive -> negative instead of also allowing negative -> positive.

Originally a gimmick via Dregora's Amp 255 debuffs and random skeletons with Invert arrows, however current 2.10's editableedibles has the Invert potion effect obtainable through the raw bookwrym meat giving potioncore:curse