### PR TITLE
fix #46 reflecting champions

### DIFF
--- a/src/main/java/rlmixins/RLMixinsPlugin.java
+++ b/src/main/java/rlmixins/RLMixinsPlugin.java
@@ -132,6 +132,7 @@ public class RLMixinsPlugin implements IFMLLoadingPlugin {
 		map.put("Cancel Parasite Reach Packet (SRParasites)", "mixins.rlmixins.srppacket.json");
 		map.put("Champion Death Message Tweak (Champions)", "mixins.rlmixins.championname.json");
 		map.put("Champion Potion Invis (Champions)", "mixins.rlmixins.championpotion.json");
+		map.put("Champion Reflective Damage Fix (Champions)", "mixins.rlmixins.championreflectivefix.json");
 		map.put("Prevent Revival Potion on Non-Players (PotionCore)", "mixins.rlmixins.potionrevival.json");
 		map.put("Parasite Spawn Fix (SRParasites)", "mixins.rlmixins.srpspawning.json");
 		map.put("Parasite Mob Spawner Fix (SRParasites)", "mixins.rlmixins.srpspawningmobspawner.json");

--- a/src/main/java/rlmixins/handlers/ForgeConfigHandler.java
+++ b/src/main/java/rlmixins/handlers/ForgeConfigHandler.java
@@ -315,6 +315,11 @@ public class ForgeConfigHandler {
 		@Config.RequiresMcRestart
 		public boolean championPotionInvis = false;
 
+		@Config.Comment("Fixes Reflecting Champions turning damage dealt to themselves into thorns damage")
+		@Config.Name("Champion Reflective Damage Fix (Champions)")
+		@Config.RequiresMcRestart
+		public boolean championReflectiveFix = false;
+
 		@Config.Comment("Blacklists PotionCore Revival/1UP potion from affecting non-players, to prevent duping.")
 		@Config.Name("Prevent Revival Potion on Non-Players (PotionCore)")
 		@Config.RequiresMcRestart

--- a/src/main/java/rlmixins/mixin/champions/AffixReflectingMixin.java
+++ b/src/main/java/rlmixins/mixin/champions/AffixReflectingMixin.java
@@ -1,0 +1,44 @@
+package rlmixins.mixin.champions;
+
+import c4.champions.common.affix.affix.AffixReflecting;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.util.DamageSource;
+import net.minecraft.util.EntityDamageSource;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(AffixReflecting.class)
+public abstract class AffixReflectingMixin {
+    @ModifyConstant(
+            method = "onDamaged",
+            constant = @Constant(stringValue = "reflecting"),
+            remap = false
+    )
+    private String rlmixins_championsAffixReflecting_onDamaged(String constant, @Local(argsOnly = true) DamageSource source){
+        return source.damageType; //don't run source.damageType = "reflecting" on the original damage source
+    }
+
+    @WrapOperation(
+            method = "onDamaged",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/util/EntityDamageSource;setIsThornsDamage()Lnet/minecraft/util/EntityDamageSource;")
+    )
+    private EntityDamageSource rlmixins_championsAffixReflecting_onDamaged(EntityDamageSource instance, Operation<EntityDamageSource> original){
+        return instance; //don't run setIsThornsDamage on the original damage source
+    }
+
+    @WrapOperation(
+            method = "onDamaged",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/EntityLivingBase;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z")
+    )
+    private boolean rlmixins_championsAffixReflecting_onDamaged(EntityLivingBase instance, DamageSource source, float amount, Operation<Boolean> original, @Local(argsOnly = true) EntityLiving champion){
+        //Use a new DamageSource instead of the current one
+        DamageSource newSource = new EntityDamageSource("reflecting", champion).setIsThornsDamage(); //for some reason this is not magic damage, so not actual thorns
+        return original.call(instance, newSource, amount);
+    }
+}

--- a/src/main/resources/mixins.rlmixins.championreflectivefix.json
+++ b/src/main/resources/mixins.rlmixins.championreflectivefix.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "package": "rlmixins.mixin",
+  "refmap": "mixins.rlmixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "champions.AffixReflectingMixin"
+  ],
+  "injectors": {
+    "maxShiftBy": 10
+  }
+}


### PR DESCRIPTION
champions with reflecting affix incorrectly turn the damage dealt to themselves into (non-magic) thorns damage. this fixes it